### PR TITLE
Ask for forgiveness when passing invalid params to boto

### DIFF
--- a/render.py
+++ b/render.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
 import boto3
-import sys
 import fileinput
 import re
-from botocore.exceptions import ParamValidationError
 
 c = "".join(fileinput.input())
 


### PR DESCRIPTION
If a config file contains no parameters our regex will produce no parameter names and boto will raise an exception.